### PR TITLE
Move Stream integration to a earlier hook

### DIFF
--- a/elasticpress-stream.php
+++ b/elasticpress-stream.php
@@ -74,4 +74,27 @@ function ep_stream_register_feature() {
 		'post_activation_cb'       => '\ElasticPress\Stream\Core\activation',
 	) );
 }
-add_action( 'ep_setup_features', 'ep_stream_register_feature', 5 );
+add_action( 'elasticpress_loaded', 'ep_stream_register_feature' );
+
+/**
+ * Load our custom driver, if we can.
+ *
+ * @since 1.1.0
+ *
+ * @param string $default_driver Name of default driver class
+ * @return string
+ */
+function ep_stream_filter_driver( $default_driver ) {
+	$feature = function_exists( 'ep_get_registered_feature' ) ? ep_get_registered_feature( 'stream' ) : false;
+
+	// If the Stream DB Driver interface exists, add our custom driver
+	if ( $feature && $feature->is_active() && interface_exists( '\WP_Stream\DB_Driver' ) ) {
+		require_once EPSTREAM_INC . 'classes/class-query.php';
+		require_once EPSTREAM_INC . 'classes/class-db-driver-elasticpress.php';
+
+		return 'ElasticPress\Stream\Driver\DB_Driver_ElasticPress';
+	}
+
+	return $default_driver;
+}
+add_filter( 'wp_stream_db_driver', 'ep_stream_filter_driver' );

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -13,8 +13,7 @@ function setup() {
 		return __NAMESPACE__ . "\\$function";
 	};
 
-	add_action( 'init', $n( 'i18n' ) );\
-	add_filter( 'wp_stream_db_driver', $n( 'driver' ) );
+	add_action( 'init', $n( 'i18n' ) );
 	add_action( 'ep_cli_put_mapping', $n( 'put_mapping' ) );
 	add_action( 'ep_put_mapping', $n( 'put_mapping' ) );
 	add_action( 'wp_stream_no_tables', '__return_true' );
@@ -183,26 +182,6 @@ function get_network_alias() {
 	$alias = $slug . '-global-stream';
 
 	return apply_filters( 'ep_stream_global_alias', $alias );
-}
-
-/**
- * Load our custom driver, if we can.
- *
- * @since 0.1.0
- *
- * @param string $default_driver Name of default driver class
- * @return string
- */
-function driver( $default_driver ) {
-	// If the Stream DB Driver interface exists, add our custom driver
-	if ( interface_exists( '\WP_Stream\DB_Driver' ) ) {
-		require_once EPSTREAM_INC . 'classes/class-query.php';
-		require_once EPSTREAM_INC . 'classes/class-db-driver-elasticpress.php';
-
-		return 'ElasticPress\Stream\Driver\DB_Driver_ElasticPress';
-	}
-
-	return $default_driver;
 }
 
 /**


### PR DESCRIPTION
Stream 3.x registers it’s DB driver during `plugins_loaded`, but EP feature setup is not until `init`. Adjusted the order of operations to register the ES driver earlier in the stack for Stream compatibility.